### PR TITLE
Added shebang line in reads_to_ctg_map.py

### DIFF
--- a/scripts/reads_to_ctg_map.py
+++ b/scripts/reads_to_ctg_map.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 '''
 Created on Jul 25, 2013
 


### PR DESCRIPTION
I have BESST installed as a module¹ on my system and the bin folder is added to the path. So with the shebang line on top i can call the script from anywhere without giving the exact path. To my knowledge it should not do any harm in any other setting.

¹: http://en.wikipedia.org/wiki/Environment_Modules_%28software%29