### PR TITLE
a few things

### DIFF
--- a/BESST/CreateGraph.py
+++ b/BESST/CreateGraph.py
@@ -905,6 +905,8 @@ def CalculateMeanCoverage(Contigs, Information, param):
         extreme_obs_occur, filtered_list = RemoveOutliers(mean_cov, std_dev, cov_of_longest_contigs)
         n = float(len(filtered_list))
         try:
+            if sum(filtered_list) == 0: # if the result of filtering brings a zero mean, keep the previous mean and don't remove any outliers
+                break
             mean_cov = sum(filtered_list) / n
         except ZeroDivisionError:
             break

--- a/scripts/reads_to_ctg_map.py
+++ b/scripts/reads_to_ctg_map.py
@@ -156,7 +156,7 @@ def bwa_mem(pe1_path, pe2_path, genome_path, threads, output_path, tmp_dir, bwa_
     with open(bwa_output, "w") as bwa_file:
         print 'Align with bwa mem...',
         stdout.flush()
-        subprocess.check_call([ bwa_path, "mem", "-t", threads,
+        subprocess.check_call([ bwa_path, "mem", "-t", threads, "-w", "0", "-O", "99", # new params found by sebastien/guillaume
                                 genome_db, pe1_path, pe2_path ],
                                 stdout=bwa_file,
                                 stderr=stderr_file)


### PR DESCRIPTION
I propose to you the following patch:

- some robustness fixes (in CreateGraph), the fix at like 908 addresses issue #42

- custom number of threads in bwa aln

- apparently better mapping parameters for bwa mem, which disallow gaps between reads and the assembly. Sebastien Letort found that it makes mapping much faster and also very slightly improved scaffolding contiguity.