### PR TITLE
change the indentation of line 137. => bug in read_to_ctg_map.py

### DIFF
--- a/scripts/reads_to_ctg_map.py
+++ b/scripts/reads_to_ctg_map.py
@@ -134,7 +134,7 @@ def bwa_sampe(pe1_path, pe2_path, genome_path, output_path, tmp_dir, bwa_path, c
         print 'Keeping genome index files for future use in ' + work_dir ,
         for f in os.listdir(work_dir):
             if not re.search("genome", f):
-            os.remove(os.path.join(work_dir, f))
+                os.remove(os.path.join(work_dir, f))
     else:
         shutil.rmtree(work_dir)
     elapsed = datetime.now() - start

--- a/scripts/reads_to_ctg_map.py
+++ b/scripts/reads_to_ctg_map.py
@@ -220,7 +220,7 @@ def bwa_mem(pe1_path, pe2_path, genome_path, threads, output_path, tmp_dir, bwa_
         print 'Keeping genome index files for future use in ' + work_dir ,
         for f in os.listdir(work_dir):
             if not re.search("genome", f):
-            os.remove(os.path.join(work_dir, f))
+                os.remove(os.path.join(work_dir, f))
     else:
         shutil.rmtree(work_dir)
     elapsed = datetime.now() - start
@@ -284,7 +284,7 @@ def map_single_reads(pe_path, genome_path, output_path, bwa_path, threads):
         print 'Keeping genome index files for future use in ' + work_dir ,
         for f in os.listdir(work_dir):
             if not re.search("genome", f):
-            os.remove(os.path.join(work_dir, f))
+                os.remove(os.path.join(work_dir, f))
     else:
         shutil.rmtree(work_dir)
 


### PR DESCRIPTION
There is an indentation pb which prohibits the execution of the script read_to_ctg_map.py
```
File "/opt/gatb-minia-pipeline/BESST/scripts/reads_to_ctg_map.py", line 137
    os.remove(os.path.join(work_dir, f))
     ^
IndentationError: expected an indented block
```
simply change the identation.